### PR TITLE
Remove availabilityZone constraint

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -199,7 +199,6 @@ resource postgresdb 'Microsoft.DBforPostgreSQL/flexibleServers@2022-01-20-previe
     version: '13'
     administratorLogin: 'django'
     administratorLoginPassword: databasePassword
-    availabilityZone: '1'
     storage: {
       storageSizeGB: 128
     }


### PR DESCRIPTION
In my experiments, deployments are more likely to succeed if availabilityZone is not specified. I would think "1" would be an okay value for all data centers, but I'm pretty sure that even "1" resulted in failed deployments. Best to not specify at all.