### PR TITLE
Update azure-dev-validate.yml with bicep workaround

### DIFF
--- a/.github/workflows/azure-dev-validate.yml
+++ b/.github/workflows/azure-dev-validate.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build Bicep for linting
         uses: azure/CLI@v1
         with:
-          inlineScript: az bicep build -f infra/main.bicep --stdout
+          inlineScript: az config set bicep.use_binary_from_path=false && az bicep build -f infra/main.bicep --stdout
 
       - name: Run Microsoft Security DevOps Analysis
         uses: microsoft/security-devops-action@preview


### PR DESCRIPTION
There's a Bicep bug right now causing your workflow to fail, this is workaround suggested by Bicep team. I'm using in all my repos as well.