### PR TITLE
Update settings.py to remove default for SECRET_KEY

### DIFF
--- a/demo-application/project/settings.py
+++ b/demo-application/project/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("SECRET_KEY", '_*&5c@1153xw6=489*2*=&*%=4)8f^m54kb@3ca-cb(wm%b@wm')
+SECRET_KEY = os.getenv("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False


### PR DESCRIPTION
This was flagged as a security issue in Azure-samples repos. Your azd template specifies SECRET_KEY, so the deployed version should be fine. I don't see instructions for running  this locally, but someone could specify SECRET_KEY as an env locally if desired.