### PR TITLE
Update django-on-azure README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,27 @@ A copy of [the slides from my Django on Azure PyCon US 2021 workshop](slides.pdf
 
 ## Deployment
 
-```console
-> azd up --template https://github.com/tonybaloney/django-on-azure
+1. Run the following command to initialize the project.
+
+```bash
+azd init --template https://github.com/tonybaloney/django-on-azure
 ```
+
+This command will clone the code to your current folder and prompt you for the following information:
+
+- `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
+
+2. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+
+```bash
+azd up
+```
+
+This command will prompt you for the following information:
+- `Azure Location`: The Azure location where your resources will be deployed.
+- `Azure Subscription`: The Azure Subscription where your resources will be deployed.
+
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
 
 Checkout the [Azure Dev CLI documentation for more instructions on using the CLI](https://docs.microsoft.com/en-us/azure/developer/azure-developer-cli/get-started?WT.mc_id=python-00000-anthonyshaw).
 


### PR DESCRIPTION
Update django-on-azure README to use `azd init` and `azd up` instead of `azd up --template`  according to https://github.com/Azure/azure-dev/issues/1769.

@jongio, @rajeshkamal5050, @tonybaloney  for notification.